### PR TITLE
minor modifications to project.services.js

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -234,6 +234,8 @@
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/src/services/project.services.js
+++ b/backend/src/services/project.services.js
@@ -1,12 +1,6 @@
 import Project from '../models/project.model.js';
-import mongoose from 'mongoose';
 
 class ProjectService {
-    validateObjectId(id, fieldName = 'ID') {
-        if (!mongoose.Types.ObjectId.isValid(id)) {
-            throw new Error(`Invalid ${fieldName} format`);
-        }
-    }
 
     async createProject(projectData, userId) {
         const { name, description, members } = projectData;
@@ -53,7 +47,6 @@ class ProjectService {
     }
 
     async updateProject(projectId, updateData, userId) {
-        this.valida
         const project = await Project.findById(projectId);
 
         if (!project) {
@@ -88,8 +81,6 @@ class ProjectService {
     }
 
     async deleteProject(projectId, userId) {
-        this.validateObjectId(projectId, 'project ID');
-        this.validateObjectId(userId, 'user ID');
 
         const project = await Project.findById(projectId);
 


### PR DESCRIPTION
This pull request primarily refactors the `ProjectService` class in `backend/src/services/project.services.js` by removing the custom object ID validation logic and its associated dependencies. Additionally, it updates the `package-lock.json` to include metadata for a development dependency.

Refactoring and dependency cleanup:

* Removed the `validateObjectId` method and its usage from `ProjectService`, simplifying the service and eliminating unnecessary validation checks. [[1]](diffhunk://#diff-98b0425d99ebb007c5a48a77afe276c8c577955f5e54bc3f7831a8e5360e54d7L2-L9) [[2]](diffhunk://#diff-98b0425d99ebb007c5a48a77afe276c8c577955f5e54bc3f7831a8e5360e54d7L56) [[3]](diffhunk://#diff-98b0425d99ebb007c5a48a77afe276c8c577955f5e54bc3f7831a8e5360e54d7L91-L92)
* Removed the import of `mongoose` from `project.services.js` since it is no longer needed after the validation method was deleted.

Dependency metadata update:

* Added `resolved` and `integrity` fields for the `@vitest/coverage-v8` package in `package-lock.json`, improving dependency tracking and security.